### PR TITLE
mvコマンドの実装 windowsのみ

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,10 @@ serde_json = "1.0.99"
 toml = "0.8.23"
 windows = { version = "0.61.3", features = [
     "Win32_Foundation",
-    "Win32_UI_Shell"
+    "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_Security",
+    "Win32_System_Registry",
+    "Win32_System",
+    "Win32_System_Threading",
 ] }

--- a/src/command.rs
+++ b/src/command.rs
@@ -22,12 +22,20 @@ pub struct Input {
 pub enum JKCommand {
     /// Command to build a JK plugin
     Build(Build),
+    /// Command to move a file
+    MV(MV),
 }
 
 #[derive(Args, Debug)]
 pub struct Build {
     #[arg(long, default_value = "none")]
     pub format: Format,
+}
+
+#[derive(Args, Debug)]
+pub struct MV {
+    /// The source file to move
+    pub src: String,
 }
 
 use clap::ValueEnum;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,14 @@
 mod command;
+use crate::command::MV;
 use crate::command::{Cargo, JKCommand};
 use cargo_metadata::Message;
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 use serde_json;
-use std::env;
+use std::{env, fs};
 use std::io;
+use std::io::Write;
+use std::path::Path;
 use std::process::Command;
 use std::process::Stdio;
 #[derive(Debug, Deserialize)]
@@ -111,5 +114,117 @@ fn main() {
                 }
             }
         }
+        JKCommand::MV(mv) => {
+            if platform::is_elevated() {
+                match mv_command(&mv) {
+                    Ok(_) => eprintln!("File moved successfully."),
+                    Err(e) => eprintln!("Failed to move file: {e}"),
+                }
+
+                println!("Press Enter to exit...");
+                let _ = io::stdout().flush();
+                let _ = io::stdin().read_line(&mut String::new());
+            } else {
+                eprintln!("Not running with elevated privileges. Attempting to elevate...");
+                platform::elevate_self();
+            }
+        },
     }
+}
+
+fn mv_command(mv: &MV) -> io::Result<()> {
+    let target_dir = Path::new("C:\\Program Files\\Adobe\\Common\\Plug-ins\\7.0\\MediaCore\\");
+
+    let src = Path::new(&mv.src);
+    // get filename from the source path
+    let filename = src.file_name().ok_or(io::Error::new(
+        io::ErrorKind::NotFound,
+        "Source file does not have a valid filename",
+    ))?;
+    let target = target_dir.join(filename);
+
+    fs::copy(src, target)
+        .map_err(|e| io::Error::other(format!("Failed to move file: {e}")))?;
+
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+mod platform {
+    use std::ffi::OsStr;
+    use std::iter::once;
+    use std::os::windows::ffi::OsStrExt;
+    use windows::{
+        core::*,
+        Win32::{Foundation::*, Security::*, System::Threading::*, UI::{Shell::*, WindowsAndMessaging::SW_SHOW}},
+    };
+
+    pub fn is_elevated() -> bool {
+        let mut token = HANDLE::default();
+        unsafe {
+            if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token).is_ok() {
+                let mut elevation = TOKEN_ELEVATION::default();
+                let mut size = std::mem::size_of::<TOKEN_ELEVATION>() as u32;
+                if GetTokenInformation(
+                    token,
+                    TokenElevation,
+                    Some(&mut elevation as *mut _ as *mut core::ffi::c_void),
+                    size,
+                    &mut size,
+                ).is_ok() {
+                    CloseHandle(token).unwrap();
+                    return elevation.TokenIsElevated != 0;
+                }
+            }
+        }
+        false
+    }
+
+pub fn elevate_self() {
+    let exe_path = std::env::current_exe().unwrap();
+
+    let args: Vec<String> = std::env::args().skip(1).collect(); // 最初は自分自身なので skip
+    let arg_str = args
+        .into_iter()
+        .map(|arg| {
+            if arg.contains(' ') {
+                format!("\"{arg}\"")
+            } else {
+                arg
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let cmd = OsStr::new(exe_path.to_str().unwrap())
+        .encode_wide()
+        .chain(once(0))
+        .collect::<Vec<u16>>();
+
+    let params = OsStr::new(&arg_str)
+        .encode_wide()
+        .chain(once(0))
+        .collect::<Vec<u16>>();
+
+    let mut sei = SHELLEXECUTEINFOW {
+        cbSize: std::mem::size_of::<SHELLEXECUTEINFOW>() as u32,
+        lpVerb: PCWSTR(w!("runas").as_ptr()),
+        lpFile: PCWSTR(cmd.as_ptr()),
+        lpParameters: PCWSTR(params.as_ptr()),
+        nShow: SW_SHOW.0,
+        fMask: SEE_MASK_NOCLOSEPROCESS,
+        ..Default::default()
+    };
+
+    unsafe {
+        if ShellExecuteExW(&mut sei).is_ok() {
+            WaitForSingleObject(sei.hProcess, INFINITE);
+            CloseHandle(sei.hProcess).unwrap();
+        } else {
+            eprintln!("Failed to elevate via UAC");
+        }
+    }
+
+    std::process::exit(0);
+}
 }


### PR DESCRIPTION
mvコマンドを実装した

```
Command to move a file

Usage: cargo jk mv [OPTIONS] <SRC>

Arguments:
  <SRC>  The source file to move

Options:
      --config <CONFIG>
  -h, --help             Print help
```

#3 