### PR TITLE
feat: implement cargo jk install command

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -24,6 +24,8 @@ pub enum JKCommand {
     Build(Build),
     /// Command to move a file
     MV(MV),
+    /// Command to build and install a JK plugin
+    Install(Install),
 }
 
 #[derive(Args, Debug)]
@@ -36,6 +38,10 @@ pub struct Build {
 pub struct MV {
     /// The source file to move
     pub src: String,
+}
+
+#[derive(Args, Debug)]
+pub struct Install {
 }
 
 use clap::ValueEnum;


### PR DESCRIPTION
Add new install command that combines build and move operations using subprocess calls:
- Runs `cargo jk build --format json` as subprocess
- Parses JSON output to extract aex file path
- Runs `cargo jk mv [path]` as subprocess

This approach uses subprocess calls instead of reimplementing logic as requested.

Generated with [Claude Code](https://claude.ai/code)