### PR TITLE
macOS環境用のmvを実装

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
 name = "camino"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +79,8 @@ version = "0.1.0"
 dependencies = [
  "cargo_metadata",
  "clap",
+ "dircpy",
+ "nix",
  "serde",
  "serde_json",
  "toml",
@@ -118,6 +126,18 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -166,6 +186,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "dircpy"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88521b0517f5f9d51d11925d8ab4523497dcf947073fa3231a311b63941131c"
+dependencies = [
+ "jwalk",
+ "log",
+ "walkdir",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +262,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -343,16 +436,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
+dependencies = [
+ "crossbeam",
+ "rayon",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "num-traits"
@@ -412,10 +539,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -659,6 +815,25 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,12 @@ edition = "2024"
 [dependencies]
 cargo_metadata = "0.20.0"
 clap = { version = "4.0", features = ["derive"] }
-serde = {version = "1.0.219",features = ["derive"] }
+dircpy = "0.3.19"
+serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.99"
 toml = "0.8.23"
+
+[target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.61.3", features = [
     "Win32_Foundation",
     "Win32_UI_Shell",
@@ -18,3 +21,6 @@ windows = { version = "0.61.3", features = [
     "Win32_System",
     "Win32_System_Threading",
 ] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+nix = { version = "0.30", features = ["user"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 [dependencies]
 cargo_metadata = "0.20.0"
 clap = { version = "4.0", features = ["derive"] }
-dircpy = "0.3.19"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.99"
 toml = "0.8.23"
@@ -24,3 +23,4 @@ windows = { version = "0.61.3", features = [
 
 [target.'cfg(target_os = "macos")'.dependencies]
 nix = { version = "0.30", features = ["user"] }
+dircpy = "0.3.19"

--- a/src/mv/macos.rs
+++ b/src/mv/macos.rs
@@ -1,0 +1,43 @@
+use std::{io, path::Path, process::Command};
+
+use nix::unistd::Uid;
+
+use crate::command::MV;
+
+pub fn is_elevated() -> bool {
+    Uid::current().is_root()
+}
+
+pub fn elevate_self() {
+    // Use `sudo` to re-run the command with elevated privileges
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let status = Command::new("sudo")
+        .arg(std::env::current_exe().unwrap())
+        .args(args)
+        .status()
+        .expect("Failed to execute sudo command");
+
+    if !status.success() {
+        eprintln!("Failed to elevate privileges");
+        std::process::exit(1);
+    }
+}
+
+// macOS
+// dst は "/Library/Application Support/Adobe/Common/Plug-ins/7.0/MediaCore/"
+// src はコマンドライン引数で指定されたパスで、windows版と違いプラグインはディレクトリなので、ディレクトリをコピーする
+pub fn mv_command(mv: &MV) -> io::Result<()> {
+    let target_dir = Path::new("/Library/Application Support/Adobe/Common/Plug-ins/7.0/MediaCore/");
+
+    let src = Path::new(&mv.src);
+    // get directory name from the source path
+    let dirname = src.file_name().ok_or(io::Error::new(
+        io::ErrorKind::NotFound,
+        "Source directory does not have a valid name",
+    ))?;
+    let target = target_dir.join(dirname);
+
+    dircpy::copy_dir(src, &target)?;
+
+    Ok(())
+}

--- a/src/mv/macos.rs
+++ b/src/mv/macos.rs
@@ -37,7 +37,8 @@ pub fn mv_command(mv: &MV) -> io::Result<()> {
     ))?;
     let target = target_dir.join(dirname);
 
-    dircpy::copy_dir(src, &target)?;
+    dircpy::copy_dir(src, &target)
+        .map_err(|e| io::Error::other(format!("Failed to move directory: {e}")))?;
 
     Ok(())
 }

--- a/src/mv/mod.rs
+++ b/src/mv/mod.rs
@@ -1,3 +1,32 @@
+//! Platform-specific implementation for the `mv` command.
+//!
+//! This module provides platform-specific implementations for moving files/directories
+//! to Adobe plugin directories. Each platform has different behavior due to how
+//! Adobe plugins are structured on different operating systems.
+//!
+//! ## Platform Behavior Differences
+//!
+//! ### Windows
+//! - **Target Directory**: `C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore\`
+//! - **Input Type**: Individual **files** (`.aex` files)
+//! - **Operation**: Copies files using `fs::copy()`
+//! - **Elevation**: Uses UAC (User Account Control) via `ShellExecuteExW`
+//!
+//! ### macOS
+//! - **Target Directory**: `/Library/Application Support/Adobe/Common/Plug-ins/7.0/MediaCore/`
+//! - **Input Type**: **Directories** (`.plugin` bundles)
+//! - **Operation**: Copies directories using `dircpy::copy_dir()`
+//! - **Elevation**: Uses `sudo` command
+//!
+//! This fundamental difference exists because:
+//! - Windows Adobe plugins are typically single `.aex` files
+//! - macOS Adobe plugins are typically `.plugin` directory bundles
+//!
+//! ## Error Handling
+//!
+//! Both platforms use standardized error handling with descriptive messages
+//! and proper error context propagation.
+
 #[cfg(target_os = "windows")]
 #[path = "windows.rs"]
 mod os_impl;

--- a/src/mv/mod.rs
+++ b/src/mv/mod.rs
@@ -1,0 +1,12 @@
+#[cfg(target_os = "windows")]
+#[path = "windows.rs"]
+mod os_impl;
+
+#[cfg(target_os = "macos")]
+#[path = "macos.rs"]
+mod os_impl;
+
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+compile_error!("mv_platform: unsupported operating system");
+
+pub use os_impl::*;

--- a/src/mv/windows.rs
+++ b/src/mv/windows.rs
@@ -1,0 +1,106 @@
+use std::{fs, io, path::Path, process::Command};
+
+use std::ffi::OsStr;
+use std::iter::once;
+use std::os::windows::ffi::OsStrExt;
+use windows::{
+    Win32::{
+        Foundation::*,
+        Security::*,
+        System::Threading::*,
+        UI::{Shell::*, WindowsAndMessaging::SW_SHOW},
+    },
+    core::*,
+};
+
+use crate::command::MV;
+
+pub fn is_elevated() -> bool {
+    let mut token = HANDLE::default();
+    unsafe {
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token).is_ok() {
+            let mut elevation = TOKEN_ELEVATION::default();
+            let mut size = std::mem::size_of::<TOKEN_ELEVATION>() as u32;
+            if GetTokenInformation(
+                token,
+                TokenElevation,
+                Some(&mut elevation as *mut _ as *mut core::ffi::c_void),
+                size,
+                &mut size,
+            )
+            .is_ok()
+            {
+                CloseHandle(token).unwrap();
+                return elevation.TokenIsElevated != 0;
+            }
+        }
+    }
+    false
+}
+
+pub fn elevate_self() {
+    let exe_path = std::env::current_exe().unwrap();
+
+    let args: Vec<String> = std::env::args().skip(1).collect(); // 最初は自分自身なので skip
+    let arg_str = args
+        .into_iter()
+        .map(|arg| {
+            if arg.contains(' ') {
+                format!("\"{arg}\"")
+            } else {
+                arg
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let cmd = OsStr::new(exe_path.to_str().unwrap())
+        .encode_wide()
+        .chain(once(0))
+        .collect::<Vec<u16>>();
+
+    let params = OsStr::new(&arg_str)
+        .encode_wide()
+        .chain(once(0))
+        .collect::<Vec<u16>>();
+
+    let mut sei = SHELLEXECUTEINFOW {
+        cbSize: std::mem::size_of::<SHELLEXECUTEINFOW>() as u32,
+        lpVerb: PCWSTR(w!("runas").as_ptr()),
+        lpFile: PCWSTR(cmd.as_ptr()),
+        lpParameters: PCWSTR(params.as_ptr()),
+        nShow: SW_SHOW.0,
+        fMask: SEE_MASK_NOCLOSEPROCESS,
+        ..Default::default()
+    };
+
+    unsafe {
+        if ShellExecuteExW(&mut sei).is_ok() {
+            WaitForSingleObject(sei.hProcess, INFINITE);
+            CloseHandle(sei.hProcess).unwrap();
+        } else {
+            eprintln!("Failed to elevate via UAC");
+        }
+    }
+
+    std::process::exit(0);
+}
+
+// Windows
+// dst は "C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore\"
+// src はコマンドライン引数で指定されたパスで、ファイルをコピーする
+pub fn mv_command(mv: &MV) -> io::Result<()> {
+    let target_dir = Path::new("C:\\Program Files\\Adobe\\Common\\Plug-ins\\7.0\\MediaCore\\");
+
+    let src = Path::new(&mv.src);
+    // get filename from the source path
+    let filename = src.file_name().ok_or(io::Error::new(
+        io::ErrorKind::NotFound,
+        "Source file does not have a valid filename",
+    ))?;
+    let target = target_dir.join(filename);
+
+    fs::copy(src, target).map_err(|e| io::Error::other(format!("Failed to move file: {e}")))?;
+
+    Ok(())
+}


### PR DESCRIPTION
- macOS環境でもmvが動くように実装
- mvコマンドのプラットフォーム固有の処理をmv modに移動
  - windows.rs と macos.rs を用意し、各環境ごとに処理が書き分けられるように修正