### PR TITLE
feat: add --release flag support to build and install commands

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -32,6 +32,9 @@ pub enum JKCommand {
 pub struct Build {
     #[arg(long, default_value = "none")]
     pub format: Format,
+    /// Build artifacts in release mode, with optimizations
+    #[arg(long)]
+    pub release: bool,
 }
 
 #[derive(Args, Debug)]
@@ -42,6 +45,9 @@ pub struct MV {
 
 #[derive(Args, Debug)]
 pub struct Install {
+    /// Build artifacts in release mode, with optimizations
+    #[arg(long)]
+    pub release: bool,
 }
 
 use clap::ValueEnum;

--- a/src/command.rs
+++ b/src/command.rs
@@ -33,7 +33,7 @@ pub struct Build {
     #[arg(long, default_value = "none")]
     pub format: Format,
     /// Build artifacts in release mode, with optimizations
-    #[arg(long)]
+    #[arg(long, default_value_t = false)]
     pub release: bool,
 }
 
@@ -46,7 +46,7 @@ pub struct MV {
 #[derive(Args, Debug)]
 pub struct Install {
     /// Build artifacts in release mode, with optimizations
-    #[arg(long)]
+    #[arg(long, default_value_t = false)]
     pub release: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,9 @@ fn main() {
             eprintln!("Plugin Name: {}", plugin_name);
             let mut command = Command::new("cargo");
             command.arg("build");
+            if build.release {
+                command.arg("--release");
+            }
             command.arg("--message-format");
             command.arg("json-render-diagnostics");
             command.stdout(Stdio::piped());
@@ -131,13 +134,13 @@ fn main() {
                 mv::elevate_self();
             }
         }
-        JKCommand::Install(_install) => {
-            install_command();
+        JKCommand::Install(install) => {
+            install_command(install.release);
         }
     }
 }
 
-fn install_command() {
+fn install_command(release: bool) {
     eprintln!("Starting install process...");
 
     // Detect if we're running in development mode (cargo run -- jk) or production mode (cargo jk)
@@ -151,15 +154,19 @@ fn install_command() {
     };
 
     // Step 1: Execute build command
-    let build_cmd = format!("{} {} build --format json", cmd_prefix, cmd_args.join(" "));
+    let release_flag = if release { " --release" } else { "" };
+    let build_cmd = format!("{} {} build{} --format json", cmd_prefix, cmd_args.join(" "), release_flag);
     eprintln!("Running: {}", build_cmd);
 
     let mut build_command = Command::new(cmd_prefix);
     for arg in &cmd_args {
         build_command.arg(arg);
     }
+    build_command.arg("build");
+    if release {
+        build_command.arg("--release");
+    }
     let build_output = build_command
-        .arg("build")
         .arg("--format")
         .arg("json")
         .output();


### PR DESCRIPTION
Add support for `--release` flag in `cargo jk build` and `cargo jk install` commands.

**Changes:**
- Add `--release` flag to Build and Install command structs
- Modify build command to pass `--release` to cargo build when flag is set
- Update install command to accept and use release flag
- Enables `cargo jk build --release` and `cargo jk install --release`

Fixes #15

Generated with [Claude Code](https://claude.ai/code)