### PR TITLE
JkPluginMetadata に identifier を持たせる / 周辺実装のリファクタリング

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,6 @@ dependencies = [
  "plist",
  "serde",
  "serde_json",
- "toml",
  "windows",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ clap = { version = "4.0", features = ["derive"] }
 plist = "1.7.2"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.99"
-toml = "0.8.23"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.61.3", features = [

--- a/src/build/windows.rs
+++ b/src/build/windows.rs
@@ -1,16 +1,14 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use serde::{Deserialize, Serialize};
+use crate::command::Build;
 
-use crate::command::{self, Build};
-
-pub fn post_build_process(
-    build: &Build,
-    filename: &Option<std::path::PathBuf>,
-    build_name: &str,
+pub fn post_build_process<P: AsRef<Path>>(
+    _build: &Build,
+    filename: P,
+    _package_name: &str,
     plugin_name: &str,
 ) -> PathBuf {
-    let dllfilepath = filename.as_ref().expect("No artifact filename found");
+    let dllfilepath = filename.as_ref().to_path_buf();
     let dllfiledir = dllfilepath.parent().unwrap();
     // rename the DLL file to the plugin name
     let new_dll_path = dllfiledir.join(&plugin_name).with_extension("aex");


### PR DESCRIPTION
- `metadata.jk_plugin.build_name` を削除し、Cargo.toml のパッケージ名で代替
  - Closes #22
- metadata.jk_plugin.identifier を実装し、macOSでのビルド時にそれを使用するように変更
  - Closes #21
- `metadata.jk_plugin` の取得方法をcargo_metadata を使用するように変更
- その他、不要そうに見えるOptionの使用箇所の削除とか